### PR TITLE
Merchant todo list

### DIFF
--- a/app/controllers/dashboard/dashboard_controller.rb
+++ b/app/controllers/dashboard/dashboard_controller.rb
@@ -2,5 +2,8 @@ class Dashboard::DashboardController < Dashboard::BaseController
   def index
     @merchant = current_user
     @pending_orders = Order.pending_orders_for_merchant(current_user.id)
+    @items_with_placeholder_image = @merchant.items_with_placeholder_image
+    @unfulfilled_orders_count = @merchant.unfulfilled_orders_count
+    @unfulfilled_orders_revenue = @merchant.unfulfilled_orders_revenue
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -48,4 +48,10 @@ class Item < ApplicationRecord
   def ordered?
     order_items.count > 0
   end
+
+  def inventory_less_than_ordered_items
+    oi_sum = order_items.sum(:quantity)
+    dif = inventory - oi_sum
+    dif < 0
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -8,6 +8,14 @@ class Order < ApplicationRecord
 
   enum status: [:pending, :packaged, :shipped, :cancelled]
 
+  def item_quantity_greater_than_inventory
+    i = items.joins(:order_items)
+            .select('items.*')
+            .group('order_items.id')
+            .sum('DISTINCT(items.inventory - order_items.quantity)')
+    i.values.any? { |value| value < 0 }
+  end
+
   def total_item_count
     order_items.sum(:quantity)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -97,6 +97,22 @@ class User < ApplicationRecord
          .limit(1).first
   end
 
+  def items_with_placeholder_image
+    items.where('image LIKE ?', '%picsum.photo%')
+  end
+
+  def unfulfilled_orders_count
+    Order.joins(:items)
+        .where('items.merchant_id' => self.id, 'orders.status' => 'pending')
+        .distinct.count(:id)
+  end
+
+  def unfulfilled_orders_revenue
+    Order.joins(:items).where('items.merchant_id' => self.id, 'orders.status' => 'pending')
+    .sum('order_items.quantity * order_items.price')
+
+  end
+
   def self.active_merchants
     where(role: :merchant, active: true)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -110,7 +110,6 @@ class User < ApplicationRecord
   def unfulfilled_orders_revenue
     Order.joins(:items).where('items.merchant_id' => self.id, 'orders.status' => 'pending')
     .sum('order_items.quantity * order_items.price')
-
   end
 
   def self.active_merchants

--- a/app/views/dashboard/dashboard/index.html.erb
+++ b/app/views/dashboard/dashboard/index.html.erb
@@ -99,7 +99,8 @@
           <%= order.id %>
           <% end %></td>
           <td><%= order.created_at %></td>
-          <td><%= order.total_quantity_for_merchant(@merchant.id) %></td>
+          <td><%= order.total_quantity_for_merchant(@merchant.id) %>
+            <%= "!Order items quantity exceed inventory!" if order.item_quantity_greater_than_inventory %></td>
           <td><%= order.total_price_for_merchant(@merchant.id) %></td>
         </tr>
       <% end %>

--- a/app/views/dashboard/dashboard/index.html.erb
+++ b/app/views/dashboard/dashboard/index.html.erb
@@ -106,3 +106,20 @@
     </tbody>
   </table>
 <% end %>
+
+<h2>Merchant To-Do List:</h2>
+<br>
+<h4>Items that need pictures:</h4>
+<% if @items_with_placeholder_image != nil %>
+  <% @items_with_placeholder_image.each do |item| %>
+    <div id="placeholder-image-item-<%= item.id %>">
+      <%= link_to "#{item.name}", edit_dashboard_item_path(item.id) %>
+    <div>
+  <% end %>
+<% end %>
+<br>
+<h4>Unfulfilled Orders:</h4>
+  <div id="unfulfilled-order-stats">
+    You have <%= @unfulfilled_orders_count %> unfulfilled orders worth $<%= @unfulfilled_orders_revenue %>
+  </div>
+<br>

--- a/app/views/dashboard/items/_item_card.html.erb
+++ b/app/views/dashboard/items/_item_card.html.erb
@@ -7,7 +7,7 @@
   <img id="item-<%= item.id %>-image" alt="image for <%= item.name %>" src="<%= item.image %>" width="<%= img_width %>" />
   </a>
   <p>Price: <%= number_to_currency(item.price) %></p>
-  <p>Inventory: <%= item.inventory %></p>
+  <p>Inventory: <%= item.inventory %><br><%= "Warning: Order items quantity exceed inventory!" if item.inventory_less_than_ordered_items %></p>
   <% if item.active? %>
     <%= button_to "Disable Item", dashboard_disable_item_path(item), method: :patch %>
   <% else %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -111,6 +111,7 @@ order_item_35 = OrderItem.create!(item: tony, order: order_17, quantity: 1, pric
 order_item_36 = OrderItem.create!(item: cal, order: order_18, quantity: 1, price: cal.price, fulfilled: true, created_at: 2.days.ago, updated_at: 1.days.ago)
 order_item_37 = OrderItem.create!(item: ken, order: order_19, quantity: 1, price: ken.price, fulfilled: true, created_at: 5.days.ago, updated_at: 1.days.ago)
 order_item_38 = OrderItem.create!(item: ryan, order: order_20, quantity: 1, price: ryan.price, fulfilled: true, created_at: 4.days.ago, updated_at: 1.days.ago)
+order_item_39 = OrderItem.create!(item: honus, order: order_8, quantity: 3, price: honus.price, fulfilled: false)
 
 puts 'seed data finished'
 puts "Users created: #{User.count.to_i}"

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe 'merchant dashboard' do
     address = create(:address, user: user)
     @merchant = create(:merchant)
     @admin = create(:admin)
-    @i1 = create(:item, user: @merchant, image: 'www.photo.com')
-    @i2 = create(:item, user: @merchant)
+    @i1 = create(:item, user: @merchant, inventory: 0, image: 'www.photo.com')
+    @i2 = create(:item, user: @merchant, inventory: 5)
     @o1 = create(:order, address: address)
     @o2 = create(:order, address: address)
     @o3 = create(:shipped_order, address: address)
@@ -71,6 +71,23 @@ RSpec.describe 'merchant dashboard' do
         expect(page).to have_link(@o2.id)
         expect(page).to have_content(@o2.created_at)
         expect(page).to have_content(@o2.total_quantity_for_merchant(@merchant.id))
+        expect(page).to have_content(@o2.total_price_for_merchant(@merchant.id))
+      end
+    end
+
+    it 'shows warning if order item quantity exceeds inventory' do
+      within("#order-#{@o1.id}") do
+        expect(page).to have_link(@o1.id)
+        expect(page).to have_content(@o1.created_at)
+        expect(page).to have_content(@o1.total_quantity_for_merchant(@merchant.id))
+        expect(page).to have_content("!Order items quantity exceed inventory!")
+        expect(page).to have_content(@o1.total_price_for_merchant(@merchant.id))
+      end
+      within("#order-#{@o2.id}") do
+        expect(page).to have_link(@o2.id)
+        expect(page).to have_content(@o2.created_at)
+        expect(page).to have_content(@o2.total_quantity_for_merchant(@merchant.id))
+        expect(page).to_not have_content("!Order items quantity exceed inventory!")
         expect(page).to have_content(@o2.total_price_for_merchant(@merchant.id))
       end
     end

--- a/spec/features/merchants/items_index_spec.rb
+++ b/spec/features/merchants/items_index_spec.rb
@@ -3,11 +3,13 @@ require 'rails_helper'
 RSpec.describe "Merchant index page" do
   before :each do
     @merchant = create(:merchant)
+    user = create(:user)
+    address = create(:address, user: user)
     @item_1, @item_2 = create_list(:item, 2, user: @merchant)
     @item_3 = create(:inactive_item, user: @merchant)
-    @order_1, @order_2 = create_list(:order, 2)
-    @order_3 = create(:shipped_order)
-    @order_4 = create(:cancelled_order)
+    @order_1, @order_2 = create_list(:order, 2, address: address)
+    @order_3 = create(:shipped_order, address: address)
+    @order_4 = create(:cancelled_order, address: address)
     create(:order_item, order: @order_1, item: @item_1, quantity: 1, price: 2)
     create(:order_item, order: @order_1, item: @item_2, quantity: 2, price: 2)
     create(:order_item, order: @order_2, item: @item_2, quantity: 4, price: 2)

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -52,12 +52,27 @@ RSpec.describe Item, type: :model do
 
   describe 'instance methods' do
     before :each do
+      user = create(:user)
+      @address = create(:address, user: user)
       @merchant = create(:merchant)
-      @item = create(:item, user: @merchant)
-      @order_item_1 = create(:fulfilled_order_item, item: @item, created_at: 4.days.ago, updated_at: 12.hours.ago)
-      @order_item_2 = create(:fulfilled_order_item, item: @item, created_at: 2.days.ago, updated_at: 1.day.ago)
-      @order_item_3 = create(:fulfilled_order_item, item: @item, created_at: 2.days.ago, updated_at: 1.day.ago)
-      @order_item_4 = create(:order_item, item: @item, created_at: 2.days.ago, updated_at: 1.day.ago)
+      @item = create(:item, user: @merchant, inventory: 10)
+      order = create(:order, address: @address)
+      @order_item_1 = create(:fulfilled_order_item, item: @item, quantity: 2, order: order, created_at: 4.days.ago, updated_at: 12.hours.ago)
+      @order_item_2 = create(:fulfilled_order_item, item: @item, quantity: 2, order: order, created_at: 2.days.ago, updated_at: 1.day.ago)
+      @order_item_3 = create(:fulfilled_order_item, item: @item, quantity: 2, order: order, created_at: 2.days.ago, updated_at: 1.day.ago)
+      @order_item_4 = create(:order_item, item: @item, quantity: 2, order: order, created_at: 2.days.ago, updated_at: 1.day.ago)
+    end
+
+    it '.inventory_less_than_ordered_items' do
+      item2 = create(:item, user: @merchant, inventory: 10)
+      order2 = create(:order, address: @address)
+      order3 = create(:order, address: @address)
+      oi1 = create(:order_item, item: @item, quantity: 3, order: order2)
+      oi2 = create(:order_item, item: item2, quantity: 5, order: order2)
+      oi3 = create(:order_item, item: item2, quantity: 4, order: order3)
+
+      expect(@item.inventory_less_than_ordered_items).to eq(true)
+      expect(item2.inventory_less_than_ordered_items).to eq(false)
     end
 
     describe "#average_fulfillment_time" do

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -121,8 +121,10 @@ RSpec.describe Order, type: :model do
       @oi_2 = create(:fulfilled_order_item, order: @order, item: @item_2, price: 2, quantity: 1, created_at: yesterday, updated_at: 2.hours.ago)
 
       @merchant = create(:merchant)
-      @i1, @i2 = create_list(:item, 2, user: @merchant)
-      @o1, @o2 = create_list(:order, 2, address: address)
+      @i1 = create(:item, user: @merchant, inventory: 0)
+      @i2 = create(:item, user: @merchant, inventory: 5)
+      @o1 = create(:order, address: address)
+      @o2 = create(:order, address: address)
       @o3 = create(:shipped_order, address: address)
       @o4 = create(:cancelled_order, address: address)
       create(:order_item, order: @o1, item: @i1, quantity: 1, price: 2)
@@ -130,6 +132,11 @@ RSpec.describe Order, type: :model do
       create(:order_item, order: @o2, item: @i2, quantity: 4, price: 2)
       create(:order_item, order: @o3, item: @i1, quantity: 4, price: 2)
       create(:order_item, order: @o4, item: @i2, quantity: 5, price: 2)
+    end
+
+    it '.item_quantity_greater_than_inventory' do
+      expect(@o1.item_quantity_greater_than_inventory).to eq(true)
+      expect(@o2.item_quantity_greater_than_inventory).to eq(false)
     end
 
     it '.total_quantity_for_merchant' do


### PR DESCRIPTION
- Merchants should be shown a list of items which are using a placeholder image and encouraged to find an appropriate image instead; each item is a link to that item's edit form.

- Merchants should see a statistic about unfulfilled items and the revenue impact. eg, "You have 5 unfulfilled orders worth $752.86"

- Next to each order on their dashboard, Merchants should see a warning if an item quantity on that order exceeds their current inventory count.

- If several orders exist for an item, and their summed quantity exceeds the Merchant's inventory for that item, a warning message is shown.